### PR TITLE
Removed the need for code when arming

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # node-red-contrib-sectoralarm
 
 A Node-RED node to connect to your Sector Alarm site which enables you to toggle your alarm, fetch the current status and your alarms recent event history. You can also inject checks at intervals, so you can get notified when the alarm's status change. Typical usage would be turning on/off lights when arming or disarming your alarm.
+
 ## Supported features
 
 * Checking current status of alarm, annex and connected door locks

--- a/README.md
+++ b/README.md
@@ -1,14 +1,6 @@
 # node-red-contrib-sectoralarm
 
 A Node-RED node to connect to your Sector Alarm site which enables you to toggle your alarm, fetch the current status and your alarms recent event history. You can also inject checks at intervals, so you can get notified when the alarm's status change. Typical usage would be turning on/off lights when arming or disarming your alarm.
-
-# Fork changes
-This was forked from Per Brage project https://github.com/perbrage/node-red-contrib-sectoralarm
-I only removed the need for entering your alarm code when arming or partially arming your system.
-Since this option can be set, at least for the Swedish systems, it was time to implement.
-I also sent a pull request to the original repository but the oldest untouched pull reqeust is almost
-two years old. All other code and text is made by Per Brage. Thanks Per! /Kristofer
-
 ## Supported features
 
 * Checking current status of alarm, annex and connected door locks

--- a/README.md
+++ b/README.md
@@ -2,6 +2,13 @@
 
 A Node-RED node to connect to your Sector Alarm site which enables you to toggle your alarm, fetch the current status and your alarms recent event history. You can also inject checks at intervals, so you can get notified when the alarm's status change. Typical usage would be turning on/off lights when arming or disarming your alarm.
 
+# Fork changes
+This was forked from Per Brage project https://github.com/perbrage/node-red-contrib-sectoralarm
+I only removed the need for entering your alarm code when arming or partially arming your system.
+Since this option can be set, at least for the Swedish systems, it was time to implement.
+I also sent a pull request to the original repository but the oldest untouched pull reqeust is almost
+two years old. All other code and text is made by Per Brage. Thanks Per! /Kristofer
+
 ## Supported features
 
 * Checking current status of alarm, annex and connected door locks

--- a/lib/sectoralarm-site.js
+++ b/lib/sectoralarm-site.js
@@ -186,12 +186,6 @@ module.exports = function(RED) {
     }
 
     function arm(node, credentials) {
-
-        if ((credentials.code == undefined || !credentials.code.trim())) {
-            sendError(node, _ARM, _ERR_INVALID_CODE, "The arm feature needs a 'Code' configured in node settings");
-            return;
-        }
-
         node.status({fill:"yellow", shape:"ring", text:"Working ..."});
 
         node._site.arm(credentials.code)
@@ -212,12 +206,6 @@ module.exports = function(RED) {
     }
 
     function partialArm(node, credentials) {
-
-        if ((credentials.code == undefined || !credentials.code.trim())) {
-            sendError(node, _PARTIALARM, _ERR_INVALID_CODE, "The partialArm feature needs a 'Code' configured in node settings");
-            return;
-        }
-
         node.status({fill:"yellow", shape:"ring", text:"Working ..."});
 
         node._site.partialArm(credentials.code)

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "node-red-contrib-sectoralarm",
-  "version": "1.3.4",
-  "description": "Adds the ability to react to changes in armed status of Sector Alarm sites, as well as change the alarm status",
+  "version": "1.0.0",
+  "description": "Adds the ability to react to changes in armed status of Sector Alarm sites, as well as change the alarm status. This module removes the need for the alarm code to arm the system.",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
   },
@@ -10,17 +10,17 @@
     "sectoralarm",
     "alarm"
   ],
-  "author": "Per Brage",
+  "author": "Per Brage changed by Kristofer Källsbo",
   "license": "MIT",
   "dependencies": {
     "sectoralarm": "2.0.5"
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/perbrage/node-red-contrib-sectoralarm"
+    "url": "https://github.com/kallsbo/node-red-contrib-sectoralarm"
   },
   "bugs": {
-    "url": "https://github.com/perbrage/node-red-contrib-sectoralarm/issues"
+    "url": "https://github.com/kallsbo/node-red-contrib-sectoralarm/issues"
   },
   "node-red": {
     "nodes": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-red-contrib-sectoralarm-code-optional",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Adds the ability to react to changes in armed status of Sector Alarm sites, as well as change the alarm status. This module removes the need for the alarm code to arm the system.",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "node-red-contrib-sectoralarm-code-optional",
-  "version": "1.0.1",
-  "description": "Adds the ability to react to changes in armed status of Sector Alarm sites, as well as change the alarm status. This module removes the need for the alarm code to arm the system.",
+  "name": "node-red-contrib-sectoralarm",
+  "version": "1.3.4",
+  "description": "Adds the ability to react to changes in armed status of Sector Alarm sites, as well as change the alarm status",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
   },
@@ -10,17 +10,17 @@
     "sectoralarm",
     "alarm"
   ],
-  "author": "Per Brage changed by Kristofer Källsbo",
+  "author": "Per Brage",
   "license": "MIT",
   "dependencies": {
     "sectoralarm": "2.0.5"
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/kallsbo/node-red-contrib-sectoralarm-code-optional"
+    "url": "https://github.com/perbrage/node-red-contrib-sectoralarm"
   },
   "bugs": {
-    "url": "https://github.com/kallsbo/node-red-contrib-sectoralarm-code-optional/issues"
+    "url": "https://github.com/perbrage/node-red-contrib-sectoralarm/issues"
   },
   "node-red": {
     "nodes": {

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "node-red-contrib-sectoralarm",
+  "name": "node-red-contrib-sectoralarm-code-optional",
   "version": "1.0.0",
   "description": "Adds the ability to react to changes in armed status of Sector Alarm sites, as well as change the alarm status. This module removes the need for the alarm code to arm the system.",
   "scripts": {
@@ -17,10 +17,10 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/kallsbo/node-red-contrib-sectoralarm"
+    "url": "https://github.com/kallsbo/node-red-contrib-sectoralarm-code-optional"
   },
   "bugs": {
-    "url": "https://github.com/kallsbo/node-red-contrib-sectoralarm/issues"
+    "url": "https://github.com/kallsbo/node-red-contrib-sectoralarm-code-optional/issues"
   },
   "node-red": {
     "nodes": {


### PR DESCRIPTION
Don't want my alarm code stored in node-red. Since Sectoralarm provided the setting to arm without a code this is now possible.